### PR TITLE
call std::move to move instead of copy

### DIFF
--- a/ChessBoard/chessboard.cpp
+++ b/ChessBoard/chessboard.cpp
@@ -8,6 +8,7 @@
 
 #include <fstream>
 #include <algorithm>
+#include <utility>
 
 ChessBoard::~ChessBoard()
 {
@@ -24,7 +25,7 @@ void ChessBoard::ReadFromFile(const std::string& fileName)
 
     fileStream.open(fileName);
     while (fileStream >> lines) {
-		m_piecePositions.push_back(lines);
+		m_piecePositions.push_back(std::move(lines));
 	}
 }
 


### PR DESCRIPTION
std::move was called to take advantage of move semantics when push backing to the vector.